### PR TITLE
Addition of Personality texts to fix issue #10

### DIFF
--- a/Texts/English/PersonalityTexts_Order.xml
+++ b/Texts/English/PersonalityTexts_Order.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<infotexts language="English" nowhitespace="false" translatedname="English">
+
+<!-- Personality traits -->
+
+<personalitytrait.boperfectionist>Perfectionist</personalitytrait.boperfectionist>
+<personalitytrait.bocultist>Husk Follower</personalitytrait.bocultist>
+<personalitytrait.bocommissar>Destined Commissar</personalitytrait.bocommissar>
+<personalitytrait.bogunnut>Gun Nut</personalitytrait.bogunnut>
+<personalitytrait.botechie>Techie</personalitytrait.botechie>
+<personalitytrait.boegotistic>Egotistic</personalitytrait.boegotistic>
+<personalitytrait.boconspiracy>Conspiracy Theorist</personalitytrait.boconspiracy>
+
+</infotexts>


### PR DESCRIPTION
These additions fix an issue where the game will toss an error pertaining to missing text about the personalities. This file will add that text to fix this issue, however, a game bug will only show some of these personalities at random per campaign/mission, with 6 traits selected at random.

A partial fix to fix my fuckup, but the game still has a bug that makes personalities hit and miss.